### PR TITLE
Update een overgebleven dependency naar JUnit 4 naar JUnit 5

### DIFF
--- a/Opdrachten/src/week2/GlobalTransitionSystemTest.java
+++ b/Opdrachten/src/week2/GlobalTransitionSystemTest.java
@@ -1,7 +1,7 @@
 package week2;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.HashMap;


### PR DESCRIPTION
Dit project is geconfigureerd voor JUnit 5, maar er stonden nog twee referenties in naar `assertFalse` en `assertTrue` uit JUnit 4, waardoor een project met een geconfigureerde dependency naar alleen JUnit 5 niet wilde compileren. Deze commit fixt dat.